### PR TITLE
Expand `suggest_dataset_name` to potentially suggest multiple datasets names

### DIFF
--- a/R/suggest_dataset_name.R
+++ b/R/suggest_dataset_name.R
@@ -17,7 +17,7 @@ suggest_dataset_name <- function(dataset_name) {
       "Can't find the dataset name
       {.var {dataset_name}}, or a close match.",
       i = "Find a dataset's name in the URL
-      of it's page on {.url www.opendata.nhs.scot.}"
+      of its page on {.url www.opendata.nhs.scot.}"
     ))
   }
 

--- a/R/suggest_dataset_name.R
+++ b/R/suggest_dataset_name.R
@@ -22,11 +22,11 @@ suggest_dataset_name <- function(dataset_name) {
   }
 
   # find closet match
-  closest_match <- dataset_names[which.min(string_distances)]
+  closest_match <- dataset_names[which(string_distances == min(string_distances))]
 
   # throw error with suggestion
   cli::cli_abort(c(
     "Can't find the dataset name {.var {dataset_name}}.",
-    "i" = "Did you mean '{closest_match}'?"
+    "i" = "Did you mean {?any of }{.val {closest_match}}?"
   ))
 }

--- a/tests/testthat/test-get_dataset.R
+++ b/tests/testthat/test-get_dataset.R
@@ -18,6 +18,6 @@ test_that("errors properly", {
     regexp = "Can't find the dataset name `dataset-name-with-no-close-match`"
   )
   expect_error(get_dataset("gp-practice-population"),
-    regexp = "Did you mean 'gp-practice-populations'?"
+    regexp = "Did you mean .+?gp-practice-populations.+?\\?"
   )
 })

--- a/tests/testthat/test-suggest_dataset_names.R
+++ b/tests/testthat/test-suggest_dataset_names.R
@@ -12,6 +12,13 @@ test_that("throws error and does suggest for close matches", {
     phsopendata:::suggest_dataset_name(
       "rospital-codes"
     ),
-    regexp = "Did you mean 'hospital-codes'?"
+    regexp = "Did you mean .+?\\?"
+  )
+
+  expect_error(
+    suggest_dataset_name(
+      "population"
+    ),
+    regexp = "Did you mean any of .+?\\?"
   )
 })


### PR DESCRIPTION
I noticed that for the prompt `populations` it was suggesting `hospital-codes`, this was because there were multiple 'options' that were equally 'close'. This tweak allows suggesting any amount when many are equally close.

I don't think `hospital-codes` is a good suggestion for `populations` but to fix that we'd have to change how it works out the string distances (e.g. change the `method`).