### PR TITLE
Use RETRY instead of GET

### DIFF
--- a/R/phs_GET.R
+++ b/R/phs_GET.R
@@ -3,20 +3,20 @@
 #' @inheritParams request_url
 #' @param verbose TRUE or FALSE. If TRUE, a success message will be printed to the console.
 #' @return content of a httr::GET request
-#'
 phs_GET <- function(action, query, verbose = FALSE) {
   # define URL
   url <- request_url(action, query)
 
-  # attempt GET request
-  response <- httr::GET(
+  # Attempt GET request, gently retrying up to 3 times
+  response <- httr::RETRY(
+    verb = "GET",
     url = url,
     user_agent = httr::user_agent(
       "https://github.com/Public-Health-Scotland/phsmethods"
     )
   )
 
-  # Check for response from server
+  # Check for a response from the server
   if (!inherits(response, "response")) {
     cli::cli_abort(c(
       "Can't connect to the CKAN server.",
@@ -24,7 +24,7 @@ phs_GET <- function(action, query, verbose = FALSE) {
     ))
   }
 
-  # extract content from HTTP response
+  # Extract the content from the HTTP response
   content <- httr::content(
     response
   )


### PR DESCRIPTION
This should mean that any failed requests will be retried up to 3 times on a failure. The function will wait a random amount of time, progressively longer on each retry, so as not to overwhelm the server.

It should clear up the intermittent errors we get.

Possibly we want to use `quiet = TRUE` - at the moment it will print a message when it has to retry informing how long it will wait before trying again.