### PR TITLE
don't retry on 409 status

### DIFF
--- a/R/phs_GET.R
+++ b/R/phs_GET.R
@@ -11,6 +11,7 @@ phs_GET <- function(action, query, verbose = FALSE) {
   response <- httr::RETRY(
     verb = "GET",
     url = url,
+    terminate_on = c(409),
     user_agent = httr::user_agent(
       "https://github.com/Public-Health-Scotland/phsmethods"
     )

--- a/R/phs_GET.R
+++ b/R/phs_GET.R
@@ -13,7 +13,7 @@ phs_GET <- function(action, query, verbose = FALSE) {
     url = url,
     terminate_on = c(409),
     user_agent = httr::user_agent(
-      "https://github.com/Public-Health-Scotland/phsmethods"
+      "phsopendata (https://github.com/Public-Health-Scotland/phsopendata)"
     )
   )
 

--- a/tests/testthat/test-get_dataset.R
+++ b/tests/testthat/test-get_dataset.R
@@ -44,3 +44,9 @@ test_that("get_dataset errors properly", {
     regexp = "Did you mean .+?gp-practice-populations.+?\\?"
   )
 })
+
+test_that("get_dataset filters error properly", {
+  expect_error(get_dataset("gp-practice-populations", col_select = "Non-existent column"),
+               regexp = "API error"
+  )
+})

--- a/tests/testthat/test-get_dataset.R
+++ b/tests/testthat/test-get_dataset.R
@@ -47,6 +47,6 @@ test_that("get_dataset errors properly", {
 
 test_that("get_dataset filters error properly", {
   expect_error(get_dataset("gp-practice-populations", col_select = "Non-existent column"),
-               regexp = "API error"
+    regexp = "API error"
   )
 })


### PR DESCRIPTION
Terminates the request on status code 409 (eg. selecting columns that don`t exist) instead of retrying.