### PR TITLE
Workaround for #15

### DIFF
--- a/R/parse_row_filters.R
+++ b/R/parse_row_filters.R
@@ -41,6 +41,12 @@ parse_row_filters <- function(row_filters, call = rlang::caller_env()) {
     )
   }
 
+  # Check if Sex = All was specified
+  # There is a bug on CKAN which makes this not work, unless we use the SQL endpoint
+  if ("Sex" %in% names(row_filters) && "All" %in% row_filters[["Sex"]]) {
+    return(FALSE)
+  }
+
   # check if any filters in list have length > 1
   multiple <- purrr::map_lgl(row_filters, ~ length(.x) > 1)
 

--- a/tests/testthat/test-get_resource.R
+++ b/tests/testthat/test-get_resource.R
@@ -124,3 +124,22 @@ test_that("errors on invalid filters", {
     regexp = "col_select: invalid value"
   )
 })
+
+test_that("We can filter data with `Sex = 'All'`", {
+  pops <- get_resource(
+    res_id = "27a72cc8-d6d8-430c-8b4f-3109a9ceadb1",
+    row_filters = list("Sex" = "All"),
+    col_select = c("Year", "HB", "AllAges", "Sex")
+  )
+
+  expect_s3_class(pops, "tbl_df")
+  expect_equal(nrow(pops), 645)
+  expect_named(pops, c(
+    "Year",
+    "HB",
+    "AllAges",
+    "Sex"
+  ))
+  expect_length(unique(pops$HB), 15)
+  expect_setequal(pops$Sex, "All")
+})

--- a/tests/testthat/test-parse_row_filters.R
+++ b/tests/testthat/test-parse_row_filters.R
@@ -29,6 +29,23 @@ test_that("returns FALSE for length > 1", {
   )
 })
 
+test_that("returns FALSE if `Sex = 'All'` is given", {
+  expect_false(
+    parse_row_filters(list("Sex" = "All"))
+  )
+
+  expect_false(
+    parse_row_filters(list("Sex" = c("Male", "All")))
+  )
+
+  expect_false(
+    parse_row_filters(list(
+      "Sex" = "All",
+      "HBT" = "S1234"
+    ))
+  )
+})
+
 test_that("throws error when un-named", {
   expect_error(
     parse_row_filters(list(1, 2)),


### PR DESCRIPTION
Fixes #15 

When we detect `Sex = "All"` in the filters it now defaults to using SQL, this PR is dependent on #54 