### PR TITLE
Don't guess column types from first 1000 rows when parsing content from a response

### DIFF
--- a/R/phs_GET.R
+++ b/R/phs_GET.R
@@ -31,9 +31,7 @@ phs_GET <- function(action, query, verbose = FALSE, call = rlang::caller_env()) 
   }
 
   # Extract the content from the HTTP response
-  content <- httr::content(
-    response
-  )
+  content <- httr::content(response, guess_max = Inf)
 
   # detect/handle errors
   error_check(content, call = call)

--- a/tests/testthat/test-get_resource.R
+++ b/tests/testthat/test-get_resource.R
@@ -21,7 +21,7 @@ test_that("returns data in the expected format", {
   expect_named(data_q, c("PracticeCode", "AddressLine1"))
   expect_equal(data_q[["PracticeCode"]], 10002)
 
-  expect_no_warning(get_resource("3e86b6fb-2062-4f05-8f4d-0bb001155d64"), "One or more parsing issues,"
+  expect_no_warning(get_resource("3e86b6fb-2062-4f05-8f4d-0bb001155d64"))
 })
 
 test_that("returns data with row specifications", {

--- a/tests/testthat/test-get_resource.R
+++ b/tests/testthat/test-get_resource.R
@@ -20,6 +20,8 @@ test_that("returns data in the expected format", {
 
   expect_named(data_q, c("PracticeCode", "AddressLine1"))
   expect_equal(data_q[["PracticeCode"]], 10002)
+
+  expect_no_warning(get_resource("3e86b6fb-2062-4f05-8f4d-0bb001155d64"), "One or more parsing issues,"
 })
 
 test_that("returns data with row specifications", {


### PR DESCRIPTION
We were seeing this warning with some resources ("3e86b6fb-2062-4f05-8f4d-0bb001155d64" and "38f813ec-efaa-42fc-bde6-b21339583bf7").
```
Warning message:                                                                                           
One or more parsing issues, call `problems()` on your data frame for details, e.g.:
  dat <- vroom(...)
  problems(dat) 
```

The issue was that when `httr::content` parses the response using `readr::read_csv`, the default guess is 1000 rows. So, for some large resources, the first 1000 contain one type (i.e. blank / NA), and it incorrectly guesses the column type, then throws a warning when a later row doesn't match its guess.

This fix is very small and doesn't slow anything down.

