### PR TITLE
Depend explicitly on readr

### DIFF
--- a/R/phs_GET.R
+++ b/R/phs_GET.R
@@ -31,7 +31,18 @@ phs_GET <- function(action, query, verbose = FALSE, call = rlang::caller_env()) 
   }
 
   # Extract the content from the HTTP response
-  content <- httr::content(response, guess_max = Inf)
+  if (httr::http_type(response) %in% c("text/html", "application/json")) {
+    content <- httr::content(response)
+  } else if (httr::http_type(response) == "text/csv") {
+    content <- readr::read_csv(
+      file = httr::content(response, as = "text"),
+      guess_max = Inf
+    )
+  } else {
+    cli::cli_abort(
+      "The response contained an unhandled content type: {httr::http_type(response)}"
+    )
+  }
 
   # detect/handle errors
   error_check(content, call = call)


### PR DESCRIPTION
This makes readr a dependency (not just 'suggested') as it is always required.

This has been changed a few times: https://github.com/search?q=repo%3APublic-Health-Scotland%2Fphsopendata+readr&type=commits I think the confusion is that the code didn't use any readr functions explicitly it was just needed by `httr::content` when parsing some CSV data that was contained in a response.

This now explicitly uses readr::read_csv, which should make it clear why it is needed, and also deal with the R-CMD-CHECK note, that 'readr is imported but not used'