### PR TITLE
Address the R CMD CHECK NOTE in newer R versions

### DIFF
--- a/R/parse_row_filters.R
+++ b/R/parse_row_filters.R
@@ -11,7 +11,7 @@ parse_row_filters <- function(row_filters, call = rlang::caller_env()) {
   }
 
   # Check if `row_filters` is a list or a character or numeric vector
-  if (class(row_filters) != "list" && !is.character(row_filters) && !is.numeric(row_filters)) {
+  if (!inherits(row_filters, "list") && !is.character(row_filters) && !is.numeric(row_filters)) {
     cli::cli_abort(
       "{.arg row_filters} must be a named {.cls list} or a named
       {.cls character} or {.cls numeric} vector, not a {.cls {class(row_filters)}}.",


### PR DESCRIPTION
This check is not in our current R version (4.1.2) but is included in the newer versions. As a result, it only shows up in the CI jobs. For example: https://github.com/Public-Health-Scotland/phsopendata/actions/runs/13679978038/job/38250546098#step:6:94

Although the job isn't failing since it's just a 'NOTE,' I believe CRAN expects there to be no NOTES or, at the very least, an explanation for them. Fortunately, in this case, resolving the issue is quite straightforward.