### PR TITLE
Fix flaky test for `get_resource()`

### DIFF
--- a/R/get_dataset.R
+++ b/R/get_dataset.R
@@ -14,12 +14,13 @@
 #' @examples
 #' get_dataset("gp-practice-populations", max_resources = 2, rows = 10)
 get_dataset <- function(
-    dataset_name,
-    max_resources = NULL,
-    rows = NULL,
-    row_filters = NULL,
-    col_select = NULL,
-    include_context = FALSE) {
+  dataset_name,
+  max_resources = NULL,
+  rows = NULL,
+  row_filters = NULL,
+  col_select = NULL,
+  include_context = FALSE
+) {
   # throw error if name type/format is invalid
   check_dataset_name(dataset_name)
 

--- a/R/get_latest_resource.R
+++ b/R/get_latest_resource.R
@@ -36,11 +36,12 @@
 #' )
 #'
 get_latest_resource <- function(
-    dataset_name,
-    rows = NULL,
-    row_filters = NULL,
-    col_select = NULL,
-    include_context = TRUE) {
+  dataset_name,
+  rows = NULL,
+  row_filters = NULL,
+  col_select = NULL,
+  include_context = TRUE
+) {
   applicable_datasets <- c(
     "community-pharmacy-contractor-activity",
     "dental-practices-and-patient-registrations",

--- a/R/get_resource.R
+++ b/R/get_resource.R
@@ -27,11 +27,12 @@
 #'   col_select = wanted_cols
 #' )
 get_resource <- function(
-    res_id,
-    rows = NULL,
-    row_filters = NULL,
-    col_select = NULL,
-    include_context = FALSE) {
+  res_id,
+  rows = NULL,
+  row_filters = NULL,
+  col_select = NULL,
+  include_context = FALSE
+) {
   # check res_id
   check_res_id(res_id)
 

--- a/R/phs_GET.R
+++ b/R/phs_GET.R
@@ -6,10 +6,11 @@
 #' @keywords internal
 #' @noRd
 phs_GET <- function(
-    action,
-    query,
-    verbose = FALSE,
-    call = rlang::caller_env()) {
+  action,
+  query,
+  verbose = FALSE,
+  call = rlang::caller_env()
+) {
   # define URL
   url <- request_url(action, query)
 

--- a/tests/testthat/test-get_resource.R
+++ b/tests/testthat/test-get_resource.R
@@ -151,7 +151,7 @@ test_that("We can filter data with `Sex = 'All'`", {
   expect_equal(
     nrow(pops),
     length(unique(pops$Year)) * 15
-    )
+  )
   expect_named(
     pops,
     c(


### PR DESCRIPTION
This was failing as a new year's worth of data had been added. The test is now more resilient depending on the number of years.

Instead of expecting `n` rows, we expect `15 * number of years`.