### PR TITLE
Add readr to Imports and remove from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,13 +21,13 @@ Imports:
     httr (>= 1.0.0),
     magrittr (>= 1.0.0),
     purrr (>= 1.0.0),
+    readr (>= 1.0.0),
     rlang (>= 1.0.0),
     stringdist,
     tibble (>= 3.0.0)
 Suggests: 
     covr,
     jsonlite (>= 1.1),
-    readr (>= 1.0.0),
     testthat (>= 3.0.0),
     xml2
 Config/testthat/edition: 3


### PR DESCRIPTION
This was highlighted by the new CI in #84, I'm not quite sure how it was missed in the CRAN submission 😆 

Since `{readr}` is explicitly used by the package it should be in `Imports`, `Suggests` is for dependancies that are not essential / only needed for development.