### PR TITLE
Rewrite the 'query' using `{purrr}` to operate on the list

### DIFF
--- a/tests/testthat/test-list_all_resources.R
+++ b/tests/testthat/test-list_all_resources.R
@@ -21,6 +21,7 @@ test_that("returns data in the expected format", {
   expect_gte(ncol(all_data), 6)
 
   expect_type(all_data$resource_id, "character")
+  expect_s3_class(all_data$last_modified, "POSIXct")
   expect_true(anyDuplicated(all_data$resource_id) == 0)
   expect_false(anyNA(all_data$resource_id))
   expect_false(anyNA(all_data$dataset_id))


### PR DESCRIPTION
This code is still quite complicated, but I think it is a bit easier to read than what we had before? I definitely think it should be easier to modify, for example, to add additional variables.

I discovered purrr::chuck and purrr::pluck, which I think we should use elsewhere in the package. They have nice syntax and good behaviour when objects you expect don't exist in the list.

The gist of how this works now is: Make a tibble for each dataset, then stick them all back together!

I also parsed the modified date into a POSIXct date type, as this matches what we do elsewhere.