### PR TITLE
Improve get_resource_sql() documentation and examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,9 +32,9 @@ Suggests:
     spelling,
     testthat (>= 3.0.0),
     xml2
+Config/roxygen2/markdown: TRUE
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 LazyData: true
-Config/roxygen2/version: 8.0.0
-Config/roxygen2/markdown: TRUE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,5 +36,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 LazyData: true
-Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.0.0
+Config/roxygen2/markdown: TRUE

--- a/R/get_resource_sql.R
+++ b/R/get_resource_sql.R
@@ -1,16 +1,37 @@
 #' Get PHS Open Data using SQL
 #'
-#' @description Downloads data from the NHS Open Data platform using a SQL query. Similar to [get_resource()], but allows more flexible server-side querying. This function has a lower maximum row number (32,000 vs 99,999) for returned results.
+#' @description
+#' Downloads data from the NHS Open Data platform using a SQL query. Similar to
+#' [get_resource()], but allows more flexible server-side querying. This
+#' function has a lower maximum row number (32,000 vs 99,999) for returned
+#' results.
 #'
-#' @param sql A single `SELECT` query (character). The resource ID must be double-quoted (e.g., `SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"`), as must column names (e.g., `"Year"`). Strings require single quotes (e.g., `'value'`). This syntax is needed because the CKAN DataStore uses [PostgreSQL](https://www.postgresql.org/docs/9.2/index.html).
+#' @param sql A single `SELECT` query (character).
 #'
-#' Enclosing the query in an R raw string avoids the need to escape embedded quotes (e.g. `\"TotalCancelled\"`). Square brackets are the recommended delimiter (i.e. `r"[...]"`), because `)"` within a query (e.g. `SUM("TotalCancelled")`) would prematurely close the string. Another option is `r"{...}"`, in the rare case that the query contains `]"`.
+#' @details
+#' Only 32,000 rows can be returned from a single SQL query.
 #'
+#' @section SQL syntax:
+#' The resource ID must be double-quoted, e.g.
+#' `SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"`, as must column names,
+#' e.g. `"Year"`. Strings require single quotes, e.g. `'value'`. This syntax is
+#' needed because the CKAN DataStore uses
+#' [PostgreSQL](https://www.postgresql.org/docs/9.2/index.html).
 #'
-#' @seealso [get_resource()] for downloading a resource without using a
-#' SQL query.
+#' @section R raw strings:
+#' Enclosing the query in an R raw string avoids the need to escape embedded
+#' quotes, e.g. `\"TotalCancelled\"`. Square brackets are the recommended
+#' delimiter, i.e. `r"[...]"`, because `)"` within a query, e.g.
+#' `SUM("TotalCancelled")`, would prematurely close the string. Another option
+#' is `r"{...}"`, in the rare case that the query contains `]"`.
 #'
-#' @return A [tibble][tibble::tibble-package] with the query results. Only 32,000 rows can be returned from a single SQL query.
+#' @return
+#' A [tibble][tibble::tibble-package] with the query results. Only 32,000 rows
+#' can be returned from a single SQL query.
+#'
+#' @seealso
+#' [get_resource()] for downloading a resource without using a SQL query.
+#'
 #' @export
 #'
 #' @examplesIf isTRUE(length(curl::nslookup("www.opendata.nhs.scot", error = FALSE)) > 0L)
@@ -41,7 +62,6 @@
 #'     pops."Sex" = 'All'
 #'     AND pops."Year" > 2006
 #' ]")
-#'
 get_resource_sql <- function(sql) {
   if (length(sql) != 1L) {
     cli::cli_abort(c(

--- a/R/get_resource_sql.R
+++ b/R/get_resource_sql.R
@@ -2,7 +2,10 @@
 #'
 #' @description Downloads data from the NHS Open Data platform using a SQL query. Similar to [get_resource()], but allows more flexible server-side querying. This function has a lower maximum row number (32,000 vs 99,999) for returned results.
 #'
-#' @param sql A single PostgreSQL SELECT query (character). Must include a resource ID, which must be double-quoted (e.g., `SELECT * from "58527343-a930-4058-bf9e-3c6e5cb04010"`).
+#' @param sql A single `SELECT` query (character). The resource ID must be double-quoted (e.g., `SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"`), as must column names (e.g., `"Year"`). Strings require single quotes (e.g., `'value'`). This syntax is needed because the CKAN DataStore uses PostgreSQL.
+#'
+#' Enclosing the query in an R raw string avoids the need to escape embedded quotes (e.g. `\"TotalCancelled\"`). Square brackets are the recommended delimiter (i.e. `r"[...]"`), because `)"` within a query (e.g. `SUM("TotalCancelled")`) would prematurely close the string. Another option is `r"{...}"`, in the rare case that the query contains `]"`.
+#'
 #'
 #' @seealso [get_resource()] for downloading a resource without using a
 #' SQL query.
@@ -11,25 +14,34 @@
 #' @export
 #'
 #' @examplesIf isTRUE(length(curl::nslookup("www.opendata.nhs.scot", error = FALSE)) > 0L)
-#' sql <- "
-#'    SELECT
-#'      \"TotalCancelled\",\"TotalOperations\",\"Hospital\",\"Month\"
-#'    FROM
-#'      \"bcc860a4-49f4-4232-a76b-f559cf6eb885\"
-#'    WHERE
-#'      \"Hospital\" = 'D102H'
-#' "
-#' df <- get_resource_sql(sql)
+#' # Basic query
+#' cancelled_ops <- get_resource_sql(r"[
+#' SELECT
+#'     "TotalCancelled",
+#'     "TotalOperations",
+#'     "Hospital",
+#'     "Month"
+#' FROM
+#'     "bcc860a4-49f4-4232-a76b-f559cf6eb885"
+#' WHERE
+#'     "Hospital" = 'D102H'
+#' ]")
 #'
-#' # This is equivalent to:
-#' cols <- c("TotalCancelled", "TotalOperations", "Hospital", "Month")
-#' row_filter <- c(Hospital = "D102H")
+#' # Joining two resources
+#' hb_pop <- get_resource_sql(r"[
+#' SELECT
+#'     pops."Year",
+#'     pops."HB",
+#'     lookup."HBName",
+#'     pops."AllAges"
+#' FROM
+#'     "27a72cc8-d6d8-430c-8b4f-3109a9ceadb1" AS pops
+#'     JOIN "652ff726-e676-4a20-abda-435b98dd7bdc" AS lookup ON pops."HB" = lookup."HB"
+#' WHERE
+#'     pops."Sex" = 'All'
+#'     AND pops."Year" > 2006
+#' ]")
 #'
-#' df2 <- get_resource(
-#'   "bcc860a4-49f4-4232-a76b-f559cf6eb885",
-#'   col_select = cols,
-#'   row_filters = row_filter
-#' )
 get_resource_sql <- function(sql) {
   if (length(sql) != 1L) {
     cli::cli_abort(c(

--- a/R/get_resource_sql.R
+++ b/R/get_resource_sql.R
@@ -2,7 +2,7 @@
 #'
 #' @description Downloads data from the NHS Open Data platform using a SQL query. Similar to [get_resource()], but allows more flexible server-side querying. This function has a lower maximum row number (32,000 vs 99,999) for returned results.
 #'
-#' @param sql A single `SELECT` query (character). The resource ID must be double-quoted (e.g., `SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"`), as must column names (e.g., `"Year"`). Strings require single quotes (e.g., `'value'`). This syntax is needed because the CKAN DataStore uses PostgreSQL.
+#' @param sql A single `SELECT` query (character). The resource ID must be double-quoted (e.g., `SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"`), as must column names (e.g., `"Year"`). Strings require single quotes (e.g., `'value'`). This syntax is needed because the CKAN DataStore uses [PostgreSQL](https://www.postgresql.org/docs/9.2/index.html).
 #'
 #' Enclosing the query in an R raw string avoids the need to escape embedded quotes (e.g. `\"TotalCancelled\"`). Square brackets are the recommended delimiter (i.e. `r"[...]"`), because `)"` within a query (e.g. `SUM("TotalCancelled")`) would prematurely close the string. Another option is `r"{...}"`, in the rare case that the query contains `]"`.
 #'

--- a/man/get_resource_sql.Rd
+++ b/man/get_resource_sql.Rd
@@ -7,7 +7,7 @@
 get_resource_sql(sql)
 }
 \arguments{
-\item{sql}{A single \code{SELECT} query (character). The resource ID must be double-quoted (e.g., \verb{SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"}), as must column names (e.g., \code{"Year"}). Strings require single quotes (e.g., \code{'value'}). This syntax is needed because the CKAN DataStore uses PostgreSQL.
+\item{sql}{A single \code{SELECT} query (character). The resource ID must be double-quoted (e.g., \verb{SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"}), as must column names (e.g., \code{"Year"}). Strings require single quotes (e.g., \code{'value'}). This syntax is needed because the CKAN DataStore uses \href{https://www.postgresql.org/docs/9.2/index.html}{PostgreSQL}.
 
 Enclosing the query in an R raw string avoids the need to escape embedded quotes (e.g. \verb{\\"TotalCancelled\\"}). Square brackets are the recommended delimiter (i.e. \code{r"[...]"}), because \verb{)"} within a query (e.g. \code{SUM("TotalCancelled")}) would prematurely close the string. Another option is \code{r"{...}"}, in the rare case that the query contains \verb{]"}.}
 }

--- a/man/get_resource_sql.Rd
+++ b/man/get_resource_sql.Rd
@@ -7,16 +7,39 @@
 get_resource_sql(sql)
 }
 \arguments{
-\item{sql}{A single \code{SELECT} query (character). The resource ID must be double-quoted (e.g., \verb{SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"}), as must column names (e.g., \code{"Year"}). Strings require single quotes (e.g., \code{'value'}). This syntax is needed because the CKAN DataStore uses \href{https://www.postgresql.org/docs/9.2/index.html}{PostgreSQL}.
-
-Enclosing the query in an R raw string avoids the need to escape embedded quotes (e.g. \verb{\\"TotalCancelled\\"}). Square brackets are the recommended delimiter (i.e. \code{r"[...]"}), because \verb{)"} within a query (e.g. \code{SUM("TotalCancelled")}) would prematurely close the string. Another option is \code{r"{...}"}, in the rare case that the query contains \verb{]"}.}
+\item{sql}{A single \code{SELECT} query (character).}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} with the query results. Only 32,000 rows can be returned from a single SQL query.
+A \link[tibble:tibble-package]{tibble} with the query results. Only 32,000 rows
+can be returned from a single SQL query.
 }
 \description{
-Downloads data from the NHS Open Data platform using a SQL query. Similar to \code{\link[=get_resource]{get_resource()}}, but allows more flexible server-side querying. This function has a lower maximum row number (32,000 vs 99,999) for returned results.
+Downloads data from the NHS Open Data platform using a SQL query. Similar to
+\code{\link[=get_resource]{get_resource()}}, but allows more flexible server-side querying. This
+function has a lower maximum row number (32,000 vs 99,999) for returned
+results.
 }
+\details{
+Only 32,000 rows can be returned from a single SQL query.
+}
+\section{SQL syntax}{
+
+The resource ID must be double-quoted, e.g.
+\verb{SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"}, as must column names,
+e.g. \code{"Year"}. Strings require single quotes, e.g. \code{'value'}. This syntax is
+needed because the CKAN DataStore uses
+\href{https://www.postgresql.org/docs/9.2/index.html}{PostgreSQL}.
+}
+
+\section{R raw strings}{
+
+Enclosing the query in an R raw string avoids the need to escape embedded
+quotes, e.g. \verb{\\"TotalCancelled\\"}. Square brackets are the recommended
+delimiter, i.e. \code{r"[...]"}, because \verb{)"} within a query, e.g.
+\code{SUM("TotalCancelled")}, would prematurely close the string. Another option
+is \code{r"{...}"}, in the rare case that the query contains \verb{]"}.
+}
+
 \examples{
 \dontshow{if (isTRUE(length(curl::nslookup("www.opendata.nhs.scot", error = FALSE)) > 0L)) withAutoprint(\{ # examplesIf}
 # Basic query
@@ -49,6 +72,5 @@ WHERE
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-\code{\link[=get_resource]{get_resource()}} for downloading a resource without using a
-SQL query.
+\code{\link[=get_resource]{get_resource()}} for downloading a resource without using a SQL query.
 }

--- a/man/get_resource_sql.Rd
+++ b/man/get_resource_sql.Rd
@@ -7,7 +7,9 @@
 get_resource_sql(sql)
 }
 \arguments{
-\item{sql}{A single PostgreSQL SELECT query (character). Must include a resource ID, which must be double-quoted (e.g., \verb{SELECT * from "58527343-a930-4058-bf9e-3c6e5cb04010"}).}
+\item{sql}{A single \code{SELECT} query (character). The resource ID must be double-quoted (e.g., \verb{SELECT * FROM "58527343-a930-4058-bf9e-3c6e5cb04010"}), as must column names (e.g., \code{"Year"}). Strings require single quotes (e.g., \code{'value'}). This syntax is needed because the CKAN DataStore uses PostgreSQL.
+
+Enclosing the query in an R raw string avoids the need to escape embedded quotes (e.g. \verb{\\"TotalCancelled\\"}). Square brackets are the recommended delimiter (i.e. \code{r"[...]"}), because \verb{)"} within a query (e.g. \code{SUM("TotalCancelled")}) would prematurely close the string. Another option is \code{r"{...}"}, in the rare case that the query contains \verb{]"}.}
 }
 \value{
 A \link[tibble:tibble-package]{tibble} with the query results. Only 32,000 rows can be returned from a single SQL query.
@@ -17,25 +19,33 @@ Downloads data from the NHS Open Data platform using a SQL query. Similar to \co
 }
 \examples{
 \dontshow{if (isTRUE(length(curl::nslookup("www.opendata.nhs.scot", error = FALSE)) > 0L)) withAutoprint(\{ # examplesIf}
-sql <- "
-   SELECT
-     \"TotalCancelled\",\"TotalOperations\",\"Hospital\",\"Month\"
-   FROM
-     \"bcc860a4-49f4-4232-a76b-f559cf6eb885\"
-   WHERE
-     \"Hospital\" = 'D102H'
-"
-df <- get_resource_sql(sql)
+# Basic query
+cancelled_ops <- get_resource_sql(r"[
+SELECT
+    "TotalCancelled",
+    "TotalOperations",
+    "Hospital",
+    "Month"
+FROM
+    "bcc860a4-49f4-4232-a76b-f559cf6eb885"
+WHERE
+    "Hospital" = 'D102H'
+]")
 
-# This is equivalent to:
-cols <- c("TotalCancelled", "TotalOperations", "Hospital", "Month")
-row_filter <- c(Hospital = "D102H")
-
-df2 <- get_resource(
-  "bcc860a4-49f4-4232-a76b-f559cf6eb885",
-  col_select = cols,
-  row_filters = row_filter
-)
+# Joining two resources
+hb_pop <- get_resource_sql(r"[
+SELECT
+    pops."Year",
+    pops."HB",
+    lookup."HBName",
+    pops."AllAges"
+FROM
+    "27a72cc8-d6d8-430c-8b4f-3109a9ceadb1" AS pops
+    JOIN "652ff726-e676-4a20-abda-435b98dd7bdc" AS lookup ON pops."HB" = lookup."HB"
+WHERE
+    pops."Sex" = 'All'
+    AND pops."Year" > 2006
+]")
 \dontshow{\}) # examplesIf}
 }
 \seealso{


### PR DESCRIPTION
Closes #21 

Clarifies that R raw strings can be used to enclose an SQL query and avoid the need to escape any quotes within it. Adds two examples.