### PR TITLE
Update PHS checks workflow to version 2.7.0

### DIFF
--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -13,8 +13,8 @@ permissions:
   statuses: read
 
 jobs:
-  PHS-checks:
-    uses: Public-Health-Scotland/actions/.github/workflows/phs_package_checks.yaml@v2.6.0
+  PHS-package-checks:
+    uses: Public-Health-Scotland/actions/.github/workflows/phs_package_checks.yaml@v2.7.0
     with:
       limit_parallel: true
     permissions: 


### PR DESCRIPTION
I updated the workflow to v2.7.0 which should solve the codecov failure. I also did some renaming to make things more consistent and hopefully less confusing.