### PR TITLE
Refactor a lof of code to reuse meta data and dataset suggestion logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     httr (>= 1.0.0),
     lifecycle,
     magrittr (>= 1.0.0),
+    memoise,
     purrr (>= 1.0.0),
     readr (>= 1.0.0),
     rlang (>= 1.0.0),

--- a/R/check_dataset_name.R
+++ b/R/check_dataset_name.R
@@ -14,7 +14,7 @@ check_dataset_name <- function(dataset_name, call = rlang::caller_env()) {
   if (!inherits(dataset_name, "character")) {
     cli::cli_abort(
       c(
-        "The dataset name supplied {.var {dataset_name}} is invalid.",
+        "The dataset name supplied {.val {dataset_name}} is invalid.",
         x = "dataset_name must be of type character.",
         i = "You supplied a {.cls {class(dataset_name)[0]}} value."
       ),
@@ -25,7 +25,7 @@ check_dataset_name <- function(dataset_name, call = rlang::caller_env()) {
   if (!grepl(dataset_name_regex, dataset_name)) {
     cli::cli_abort(
       c(
-        "The dataset name supplied {.var {dataset_name}} is invalid",
+        "The dataset name supplied {.val {dataset_name}} is invalid",
         x = "dataset_name must be in dash-case
       (e.g., lowercase-words-separated-by-dashes).",
         i = "You can find dataset names in the URL

--- a/R/get_dataset.R
+++ b/R/get_dataset.R
@@ -40,24 +40,19 @@ get_dataset <- function(
   # throw error if name type/format is invalid
   check_dataset_name(dataset_name)
 
-  # define query and try API call
-  query <- list(id = dataset_name)
-  content <- try(
-    phs_GET("package_show", query),
-    silent = TRUE
-  )
+  datasets <- list_resources_query()
 
-  # if content contains a 'Not Found Error'
-  # throw error with suggested dataset name
-  if (grepl("Not Found Error", content[1L], fixed = TRUE)) {
-    suggest_dataset_name(dataset_name)
+  if (!dataset_name %in% datasets$dataset_name) {
+    suggest_dataset_name(name = dataset_name)
   }
 
+  dataset_info <- datasets[datasets$dataset_name == dataset_name, ]
+
   # define list of resource IDs to get
-  all_ids <- purrr::map_chr(content$result$resources, ~ .x$id)
+  all_ids <- dataset_info$resource_id
 
   n_res <- length(all_ids)
-  res_index <- 1L:min(n_res, max_resources)
+  res_index <- seq_len(min(n_res, max_resources))
 
   selection_ids <- all_ids[res_index]
 
@@ -79,6 +74,7 @@ get_dataset <- function(
 
   # for each df, check if next df class matches
   inconsistencies <- vector(length = length(types) - 1L, mode = "list")
+
   for (i in seq_along(types)) {
     if (i == length(types)) break
 
@@ -122,22 +118,14 @@ get_dataset <- function(
       list(
         data = all_data,
         id = selection_ids,
-        name = purrr::map_chr(content$result$resources[res_index], ~ .x$name),
-        created_date = purrr::map_chr(
-          content$result$resources[res_index],
-          ~ .x$created
-        ),
-        modified_date = purrr::map_chr(
-          content$result$resources[res_index],
-          ~ .x$last_modified
-        )
+        name = dataset_info[res_index, ]$resource_name,
+        created_date = dataset_info[res_index, ]$created,
+        modified_date = dataset_info[res_index, ]$last_modified
       ),
       add_context
     )
   }
 
   # Combine the list of resources into a single tibble
-  combined <- purrr::list_rbind(all_data)
-
-  return(combined)
+  purrr::list_rbind(all_data)
 }

--- a/R/list_resources.R
+++ b/R/list_resources.R
@@ -115,7 +115,7 @@ list_resources <- function(
   validate_regex(resource_contains, "resource_contains")
   validate_regex(dataset_contains, "dataset_contains")
 
-  data_tibble <- list_resources_query()
+  data_tibble <- dplyr::select(list_resources_query(), !"created")
 
   build_and_anywhere_regex <- function(query) {
     # Split on one-or-more whitespace
@@ -174,7 +174,7 @@ list_resources <- function(
 }
 
 
-list_resources_query <- function() {
+list_resources_query <- memoise::memoise(function() {
   # query for the API call
   query <- list(q = "*:*", rows = 3200)
 
@@ -212,12 +212,18 @@ list_resources_query <- function() {
           ),
           format = "%FT%X",
           tz = "UTC"
+        ),
+        created = as.POSIXct(
+          purrr::map_chr(
+            resources,
+            ~ purrr::pluck(.x, "created", .default = NA_character_)
+          ),
+          format = "%FT%X",
+          tz = "UTC"
         )
       )
     }
   )
 
-  data_tibble <- purrr::list_rbind(datasets_list)
-
-  return(data_tibble)
-}
+  purrr::list_rbind(datasets_list)
+})

--- a/R/resolve_dataset_title_to_name.R
+++ b/R/resolve_dataset_title_to_name.R
@@ -26,9 +26,11 @@
 #' @noRd
 resolve_dataset_title_to_name <- function(dataset_name) {
   # return malformed input unchanged for check_dataset_name()
-  if (!inherits(dataset_name, "character") ||
-    length(dataset_name) != 1 ||
-    is.na(dataset_name)) {
+  if (
+    !inherits(dataset_name, "character") ||
+      length(dataset_name) != 1 ||
+      is.na(dataset_name)
+  ) {
     return(dataset_name)
   }
 
@@ -37,48 +39,19 @@ resolve_dataset_title_to_name <- function(dataset_name) {
     return(dataset_name)
   }
 
-  # otherwise, fetch every dataset title and name for matching with input
-  # capped at 10000
-  content <- phs_GET(
-    "package_search",
-    list(
-      "q" = "*:*",
-      "rows" = 10000
-    )
-  )
-
   # extract the results
-  results <- content$result$results
-
-  # extract dataset titles from results; missing data becomes NA
-  all_titles <- purrr::map_chr(
-    results,
-    function(x) {
-      if (is.null(x$title)) NA_character_ else x$title
-    }
+  datasets <- dplyr::distinct(
+    list_resources_query(),
+    .data$dataset_name,
+    .data$dataset_title
   )
-
-  # extract dataset names from results; missing data becomes NA
-  all_names <- purrr::map_chr(
-    results,
-    function(x) {
-      if (is.null(x$name)) NA_character_ else x$name
-    }
-  )
-
-  # create a logical vector that's TRUE where titles AND names are not NA
-  dataset_index <- !is.na(all_titles) & !is.na(all_names)
-
-  # use this vector to drop results where title is not paired with name
-  all_titles <- all_titles[dataset_index]
-  all_names <- all_names[dataset_index]
 
   # check input for an exact match with all_titles (case insensitive)
-  exact_index <- tolower(all_titles) == tolower(dataset_name)
+  exact_index <- tolower(datasets$dataset_title) == tolower(dataset_name)
 
   # if there is exactly one match, resolve it with a warning
   if (sum(exact_index) == 1) {
-    resolved_name <- all_names[exact_index]
+    resolved_name <- datasets$dataset_name[exact_index]
 
     cli::cli_warn(c(
       "Dataset title {.val {dataset_name}} resolved to name {.val {resolved_name}}.",
@@ -86,42 +59,7 @@ resolve_dataset_title_to_name <- function(dataset_name) {
     ))
 
     return(resolved_name)
+  } else {
+    suggest_dataset_name(title = dataset_name)
   }
-
-  # if more than one exact title match, abort and show matching titles and names
-  if (sum(exact_index) > 1) {
-    matches <- paste0(
-      all_titles[exact_index],
-      " (",
-      all_names[exact_index],
-      ")"
-    )
-
-    cli::cli_abort(c(
-      "x" = "Dataset title {.val {dataset_name}} matched more than one dataset.",
-      "i" = paste0("Matching candidates: ", paste(matches, collapse = "; "))
-    ))
-  }
-
-  # search for input dataset_name as substring within all_titles (case insensitive)
-  candidate_index <- grepl(
-    tolower(dataset_name),
-    tolower(all_titles),
-    fixed = TRUE
-  )
-
-  # create message, handling no-match case
-  candidate_msg <-
-    if (any(candidate_index)) {
-      candidates <- paste0(all_titles[candidate_index], " (", all_names[candidate_index], ")")
-      paste0("Candidates: ", paste(candidates, collapse = "; "))
-    } else {
-      "Candidates: none"
-    }
-
-  ## abort with error message
-  cli::cli_abort(c(
-    "x" = "Dataset title {.val {dataset_name}} did not match any dataset title exactly.",
-    "i" = candidate_msg
-  ))
 }

--- a/R/suggest_dataset_name.R
+++ b/R/suggest_dataset_name.R
@@ -1,39 +1,66 @@
-#' Throw an error with suggested dataset name, if possible.
-#'
-#' @inheritParams get_dataset
+#' Suggest a dataset title from a partial name or title
+#' @param name Character string of the dataset name
+#' @param title Character string of the dataset title
 #' @keywords internal
 #' @noRd
-suggest_dataset_name <- function(dataset_name, call = rlang::caller_env()) {
-  content <- phs_GET("package_list", "")
+suggest_dataset_name <- function(
+  name = NULL,
+  title = NULL,
+  call = rlang::caller_env()
+) {
+  if (is.null(name) == is.null(title)) {
+    cli::cli_abort(
+      "You must provide exactly one argument: either {.arg name} or {.arg title}."
+    )
+  }
 
-  dataset_names <- unlist(content$result)
+  datasets <- dplyr::distinct(
+    list_resources_query(),
+    .data$dataset_name,
+    .data$dataset_title
+  )
+
+  looking_for_name <- !is.null(name)
+  looking_for_text <- if (looking_for_name) "name" else "title"
+  search_term <- if (looking_for_name) name else title
+  search_target <- if (looking_for_name) datasets$dataset_name else
+    datasets$dataset_title
 
   # calculate string distances
-  string_distances <- stringdist::stringdist(dataset_name, dataset_names)
+  string_distances <- stringdist::stringdist(search_term, search_target)
+  min_dist <- min(string_distances)
 
   # if min distance is too big, abort
-  if (min(string_distances) > 10.0) {
+  if (min_dist > 10.0) {
     cli::cli_abort(
       c(
-        "Can't find the dataset name
-      {.var {dataset_name}}, or a close match.",
-        i = "Find a dataset's name in the URL
+        "Can't find the dataset {looking_for_text}
+      {.val {search_term}}, or a close match.",
+        i = "Find a dataset's name (or title) in the URL
       of its page on {.url www.opendata.nhs.scot.}"
       ),
       call = call
     )
   }
 
-  # find closet match
-  closest_match <- dataset_names[which(
-    string_distances == min(string_distances)
-  )]
+  close_matches <- which(string_distances == min_dist)
+
+  suggestions <- if (looking_for_name) {
+    datasets$dataset_name[close_matches]
+  } else {
+    paste0(
+      datasets$dataset_name[close_matches],
+      " (title: ",
+      datasets$dataset_title[close_matches],
+      ")"
+    )
+  }
 
   # throw error with suggestion
   cli::cli_abort(
     c(
-      "Can't find the dataset name {.var {dataset_name}}.",
-      i = "Did you mean {?any of }{.val {closest_match}}?"
+      "Can't find the dataset {looking_for_text} {.var {search_term}}.",
+      i = "Did you mean {?any of }{.val {suggestions}}?"
     ),
     call = call
   )

--- a/R/suggest_dataset_name.R
+++ b/R/suggest_dataset_name.R
@@ -23,8 +23,11 @@ suggest_dataset_name <- function(
   looking_for_name <- !is.null(name)
   looking_for_text <- if (looking_for_name) "name" else "title"
   search_term <- if (looking_for_name) name else title
-  search_target <- if (looking_for_name) datasets$dataset_name else
+  search_target <- if (looking_for_name) {
+    datasets$dataset_name
+  } else {
     datasets$dataset_title
+  }
 
   # calculate string distances
   string_distances <- stringdist::stringdist(search_term, search_target)

--- a/tests/testthat/test-get_dataset.R
+++ b/tests/testthat/test-get_dataset.R
@@ -38,16 +38,16 @@ test_that("get_dataset errors properly", {
   expect_error(
     # treated as a title due to the capital letter - it matches none exactly
     get_dataset("Mal-formed-name"),
-    regexp = 'Dataset title "Mal-formed-name" did not match any dataset title exactly'
+    regexp = "Can't find the dataset title .+?Mal-formed-name.+?"
   )
   expect_error(
     # made lower case, so it passes through resolve_dataset_title_to_name()
     get_dataset("-bad-name-"),
-    regexp = "The dataset name supplied `-bad-name-` is invalid"
+    regexp = "The dataset name supplied .+?-bad-name-.+? is invalid"
   )
   expect_error(
     get_dataset("dataset-name-with-no-close-match"),
-    regexp = "Can't find the dataset name `dataset-name-with-no-close-match`"
+    regexp = "Can't find the dataset name .+?dataset-name-with-no-close-match.+?"
   )
   expect_error(
     get_dataset("gp-practice-population"),

--- a/tests/testthat/test-resolve_dataset_title_to_name.R
+++ b/tests/testthat/test-resolve_dataset_title_to_name.R
@@ -65,11 +65,10 @@ test_that("resolve_dataset_title_to_name() resolves a unique exact title match a
       mock_content
     }
   )
-  expect_warning(
-    out <- resolve_dataset_title_to_name("gp practice populations"),
-    "resolved to name"
-  )
-  expect_identical(out, "gp-practice-populations")
+
+  resolve_dataset_title_to_name("GP Practice Population Demographics") |>
+    expect_identical("gp-practice-populations") |>
+    expect_warning("resolved to name")
 })
 
 # Block 4: error if datasets share the same title (case insensitive)


### PR DESCRIPTION
Two big refactors here:

The function `list_resources_query()` is now used throughout, this returns all the metadata that is needed, and instead of doing essentially the same thing in lots of places, we now just use this. It might need renaming! I also introduced memoise for caching, as it seemed more sensible / easy to just know it was cached, rather than do an even bigger re-work to pass the metadata between all the functions.

The function `suggest_dataset_name.R` now handles either a name or a title, and in either case will suggest names (if relevant).

